### PR TITLE
update example to money text column

### DIFF
--- a/packages/tables/docs/03-columns.md
+++ b/packages/tables/docs/03-columns.md
@@ -341,7 +341,7 @@ The `money()` method allows you to easily format monetary values, in any currenc
 ```php
 use Filament\Tables\Columns\TextColumn;
 
-TextColumn::make('price')->money('eur')
+TextColumn::make('price')->money('eur', true)
 ```
 
 You may `limit()` the length of the cell's value:


### PR DESCRIPTION
This makes the example on text column compatible with the ones on https://filamentphp.com/docs/2.x/forms/fields#text-input

Also makes it compatible with the ones on the demo app.  Longer term all these examples should expect integer money values, but that isn't really possible with one simple commit